### PR TITLE
Add CSV export functionality.

### DIFF
--- a/apps/kpis/src/lib/utils.ts
+++ b/apps/kpis/src/lib/utils.ts
@@ -4,3 +4,44 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+/**
+ * Converts an array of objects to a CSV string.
+ * @param rows Array of objects (all keys should be strings)
+ * @returns CSV string
+ */
+export function arrayToCsv<T extends Record<string, any>>(rows: T[]): string {
+  if (!rows.length) return '';
+  const headers = Object.keys(rows[0]);
+  const escape = (val: any) => {
+    if (val == null) return '';
+    const str = String(val);
+    if (str.includes('"') || str.includes(',') || str.includes('\n')) {
+      return '"' + str.replace(/"/g, '""') + '"';
+    }
+    return str;
+  };
+  const csv = [headers.join(',')]
+    .concat(rows.map(row => headers.map(h => escape(row[h])).join(',')))
+    .join('\n');
+  return csv;
+}
+
+/**
+ * Triggers a download of a string as a file.
+ * @param content The file content
+ * @param filename The file name (should include .csv)
+ */
+export function downloadStringAsFile(content: string, filename: string) {
+  const blob = new Blob([content], { type: 'text/csv' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  setTimeout(() => {
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  }, 0);
+}


### PR DESCRIPTION
## Feature: CSV Export for KPI Data (Per-KPI & All-in-View)

### Overview

This PR introduces robust CSV export functionality to the KPI category view, enabling users to easily download KPI snapshot data for further analysis or sharing. The export features are fully integrated with the current filters and date range, ensuring that users always get exactly the data they see.

---

### ✨ Features

#### 1. **Per-KPI CSV Export**
- **Button:** Each KPI card now has an "Export CSV" button (with a download icon).
- **Dialog:** Clicking the button opens a dialog where the user can enter a filename (with `.csv` shown as a static suffix).
- **Download:** The CSV contains all snapshot data for that KPI, filtered by the current date range and channel selection.

#### 2. **Export All CSV**
- **Button:** An "Export All CSV" button (with a download icon) appears to the right of the KPI grid header.
- **Dialog:** Clicking the button opens a dialog for filename entry (with `.csv` as a static suffix).
- **Download:** The CSV contains all snapshot data for all KPIs currently in view, reflecting all active filters and the selected date range.

#### 3. **Dialog UX**
- Uses shadcn/ui Dialog and Input components for a modern, accessible experience.
- The Download button is visually prioritized; Cancel is present but secondary.
- The `.csv` extension is always visible and uneditable, so users don’t need to type it.

#### 4. **Visuals**
- Both export buttons and their corresponding Download actions in dialogs feature a download icon for clarity and consistency.

---

### 🛠️ Technical Notes

- **CSV Utility:** Added a utility to convert arrays of objects to CSV, handling escaping and headers.
- **Download Helper:** Added a helper to trigger file downloads from a string.
- **No new dependencies** were required; all icons and UI components are from existing libraries (Lucide, shadcn/ui).
- **Filename sanitization** ensures only safe characters are used.

---

### 🧪 How it works

- **Filters respected:** The exported CSV always matches the current view (date range, channel filters, etc).
- **User flow:** Click export → enter filename → download CSV.

---

### Demo

![CSV Export Demo](https://user-images.githubusercontent.com/your-demo-link.gif)

---

Closes #5 