### PR TITLE
Show invoice budget impact in approval view

### DIFF
--- a/apps/kpis/messages/en.json
+++ b/apps/kpis/messages/en.json
@@ -327,6 +327,18 @@
       "failedInvoices": "Failed Invoices",
       "invoiceId": "Invoice ID",
       "andMore": "...and {count} more"
+    },
+    "budget": {
+      "title": "Budget Impact",
+      "fetching": "Fetching budget...",
+      "unavailable": "Budget not available for the selected item.",
+      "analyticLabel": "Analytic",
+      "planned": "Planned",
+      "spent": "Spent (Odoo)",
+      "sessionPending": "Session Pending",
+      "remaining": "Remaining",
+      "beforeApproval": "Before Approval",
+      "afterApproval": "After Approval"
     }
   },
   "components": {

--- a/apps/kpis/messages/es.json
+++ b/apps/kpis/messages/es.json
@@ -327,6 +327,18 @@
       "failedInvoices": "Facturas Fallidas",
       "invoiceId": "ID de Factura",
       "andMore": "...y {count} más"
+    },
+    "budget": {
+      "title": "Impacto en Presupuesto",
+      "fetching": "Obteniendo presupuesto...",
+      "unavailable": "Presupuesto no disponible para el elemento seleccionado.",
+      "analyticLabel": "Analítica",
+      "planned": "Planificado",
+      "spent": "Gastado (Odoo)",
+      "sessionPending": "Pendiente (sesión)",
+      "remaining": "Restante",
+      "beforeApproval": "Antes de aprobar",
+      "afterApproval": "Después de aprobar"
     }
   },
   "components": {

--- a/apps/kpis/src/app/api/odoo/budgets/route.ts
+++ b/apps/kpis/src/app/api/odoo/budgets/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getBudgetSummaryByAnalytic } from '@/lib/odoo/services';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const analyticIdParam = searchParams.get('analytic_id');
+    if (!analyticIdParam) {
+      return NextResponse.json({ error: 'Missing analytic_id' }, { status: 400 });
+    }
+    const analyticId = parseInt(analyticIdParam, 10);
+    if (Number.isNaN(analyticId)) {
+      return NextResponse.json({ error: 'Invalid analytic_id' }, { status: 400 });
+    }
+
+    const summary = await getBudgetSummaryByAnalytic(analyticId);
+    return NextResponse.json(summary);
+  } catch (error: any) {
+    console.error('Failed to fetch budgets:', error);
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+}
+


### PR DESCRIPTION
Add a "Budget Impact" card to the invoice detail view to show before/after budget figures and a session running total for approvals.

---
<a href="https://cursor.com/background-agent?bcId=bc-ad517da2-5d97-4a38-98cf-ea0c218378e6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ad517da2-5d97-4a38-98cf-ea0c218378e6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

